### PR TITLE
General Android Support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,6 @@
 group 'id.farellsujanto.flutter_serial_communication'
 version '1.0'
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
-    }
-}
-
 rootProject.allprojects {
     repositories {
         google()
@@ -33,6 +21,10 @@ android {
 
     defaultConfig {
         minSdkVersion 21
+    }
+    
+    if (project.android.hasProperty("namespace")) {
+        namespace 'id.farellsujanto.flutter_serial_communication'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,5 +29,5 @@ android {
 }
 
 dependencies {
-    api 'com.github.mik3y:usb-serial-for-android:3.5.1'
+    api 'com.github.mik3y:usb-serial-for-android:3.8.0'
 }

--- a/android/src/main/java/id/farellsujanto/flutter_serial_communication/FlutterSerialCommunicationPlugin.java
+++ b/android/src/main/java/id/farellsujanto/flutter_serial_communication/FlutterSerialCommunicationPlugin.java
@@ -269,7 +269,7 @@ public class FlutterSerialCommunicationPlugin implements FlutterPlugin, MethodCa
 
     if (usbManager.hasPermission(driver.getDevice()) == false) {
       int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-          ? PendingIntent.FLAG_MUTABLE : 0;
+          ? PendingIntent.FLAG_IMMUTABLE : 0;
       usbGrantReceiver = new USBGrantReceiver(this);
       if (Build.VERSION.SDK_INT >= 34) {
         activity.registerReceiver(

--- a/android/src/main/java/id/farellsujanto/flutter_serial_communication/FlutterSerialCommunicationPlugin.java
+++ b/android/src/main/java/id/farellsujanto/flutter_serial_communication/FlutterSerialCommunicationPlugin.java
@@ -191,6 +191,16 @@ public class FlutterSerialCommunicationPlugin implements FlutterPlugin, MethodCa
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
     activity = (FlutterActivity) binding.getActivity();
     usbManager = (UsbManager) activity.getSystemService(Context.USB_SERVICE);
+    // TODO: Application cold started by an ACTION_USB_DEVICE_ATTACHED intent - propagate to Flutter?
+    // TODO: For example connect to the device:
+    // Intent intent = activity.getIntent();
+    // String action = intent.getAction();
+    // if(action.equals(UsbManager.ACTION_USB_DEVICE_ATTACHED)) {
+    //   UsbDevice device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+    //   Log.i("Action", action);
+    //   Log.i("UsbDevice", device.getDeviceName());
+    //   connect(device.getDeviceName());
+    // }
   }
 
   @Override

--- a/android/src/main/java/id/farellsujanto/flutter_serial_communication/FlutterSerialCommunicationPlugin.java
+++ b/android/src/main/java/id/farellsujanto/flutter_serial_communication/FlutterSerialCommunicationPlugin.java
@@ -269,13 +269,13 @@ public class FlutterSerialCommunicationPlugin implements FlutterPlugin, MethodCa
 
     if (usbManager.hasPermission(driver.getDevice()) == false) {
       int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-          ? PendingIntent.FLAG_IMMUTABLE : 0;
+          ? PendingIntent.FLAG_MUTABLE : 0;
       usbGrantReceiver = new USBGrantReceiver(this);
       if (Build.VERSION.SDK_INT >= 34) {
         activity.registerReceiver(
           usbGrantReceiver,
           new IntentFilter(PluginConfig.INTENT_ACTION_GRANT_USB),
-          Context.RECEIVER_EXPORTED
+          Context.RECEIVER_NOT_EXPORTED // this is correct, but android studio seems to have issues recognizing.
         );
       } else {
         activity.registerReceiver(
@@ -285,8 +285,9 @@ public class FlutterSerialCommunicationPlugin implements FlutterPlugin, MethodCa
       }
 
       PendingIntent usbGrantIntent = PendingIntent.getBroadcast(activity,
-          0,
-          new Intent(PluginConfig.INTENT_ACTION_GRANT_USB), flags);
+        0,
+        new Intent(PluginConfig.INTENT_ACTION_GRANT_USB).setPackage(activity.getPackageName()),
+        flags);
 
       usbManager.requestPermission(driver.getDevice(), usbGrantIntent);
     } else {

--- a/android/src/main/java/id/farellsujanto/flutter_serial_communication/PluginConfig.java
+++ b/android/src/main/java/id/farellsujanto/flutter_serial_communication/PluginConfig.java
@@ -2,7 +2,7 @@ package id.farellsujanto.flutter_serial_communication;
 
 class PluginConfig {
     public static final String INTENT_ACTION_GRANT_USB = BuildConfig.LIBRARY_PACKAGE_NAME + ".GRANT_USB";
-    public static final String SERIAL_STREAM_CHANNEL = "id.farellsujanto.flutter_serial_communication.flutter_event_channel/serialStreamChannel";
-    public static final String DEVICE_CONNECTION_STREAM_CHANNEL = "id.farellsujanto.flutter_serial_communication.flutter_event_channel/deviceConnectionStreamChannel";
+    public static final String SERIAL_STREAM_CHANNEL = BuildConfig.LIBRARY_PACKAGE_NAME + ".flutter_event_channel/serialStreamChannel";
+    public static final String DEVICE_CONNECTION_STREAM_CHANNEL = BuildConfig.LIBRARY_PACKAGE_NAME + ".flutter_event_channel/deviceConnectionStreamChannel";
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,10 +22,6 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
@@ -35,10 +32,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "id.farellsujanto.flutter_serial_communication_example"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 21
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
@@ -47,8 +41,6 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="id.farellsujanto.flutter_serial_communication_example">
+
+    <!-- Required only if you want the application to start when a usb device is attached -->
+    <uses-feature android:name="android.hardware.usb.host" />
+
    <application
         android:label="flutter_serial_communication_example"
         android:name="${applicationName}"
@@ -12,21 +16,23 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- Specifies an Android theme to apply to this Activity as soon as
-                 the Android process has started. This theme is visible to the user
-                 while the Flutter UI initializes. After that, this theme continues
-                 to determine the Window background behind the Flutter UI. -->
             <meta-data
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            
+            <!-- Edit res/xml/device_filter.xml to set your device vendor and product ids.
+                 See https://developer.android.com/guide/topics/connectivity/usb/host.html for more info. -->
+            <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+                <!-- Start app on USB_DEVICE_ATTACHED intent -->
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
             </intent-filter>
         </activity>
-        <!-- Don't delete the meta-data below.
-             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />

--- a/example/android/app/src/main/res/xml/device_filter.xml
+++ b/example/android/app/src/main/res/xml/device_filter.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <!--
+    Example:
+    note the ids are decimal numbers!
+    <usb-device vendor-id="1234" product-id="11" />
+    -->
+</resources>

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.3.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.10" apply false
+}
+
+include ":app"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.5"
+    version: "0.2.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -86,18 +86,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -126,18 +126,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -219,10 +219,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
* Fix deprecated imperative apply of Flutter's Gradle plugins. See  https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply
* If AndroidManifest and device_filter are correctly configured the application will now ask to always open the app when certain usb-devices are present:
  * Extend example AndroidManifest with meta-data for device_filter and USB_DEVICE_ATTACHED intent
  * Extend example with a device_filter.xml in android/res/xml
  * Add some example code snippet on how to consume in FlutterSerialCommunicationPlugin.java
* Register UsbGrantReceiver as RECEIVER_NOT_EXPORTED on Android 34
* Register INTENT_ACTION_GRANT_USB intent explicitly, so we can use FLAG_MUTABLE on Android 34
* Minor QOL changes