### PR TITLE
fix failure on control chars in json before decoding

### DIFF
--- a/lib/flutter_serial_communication_method_channel.dart
+++ b/lib/flutter_serial_communication_method_channel.dart
@@ -26,7 +26,7 @@ class MethodChannelFlutterSerialCommunication
       return [];
     }
 
-    final cleanedString = availableDevices.replaceAll('=', ':');
+    final cleanedString = availableDevices.replaceAll('=', ':').replaceAll(RegExp(r'[^\x09\x0A\x0D\x20-\x7E]'), '');
     final List<dynamic> rawDataList = jsonDecode(cleanedString);
 
     List<DeviceInfo> deviceInfos = [];


### PR DESCRIPTION
this regex only allow printable and usefull chars while removing some control chars producing error when listing devices.